### PR TITLE
[MWPW-158449] Added stage domains map

### DIFF
--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -113,6 +113,11 @@ const CONFIG = {
   codeRoot: '/blog',
   taxonomyRoot: '/tags',
   links: 'on',
+  stageDomainsMap: {
+    'business.stage.adobe.com': { 'business.adobe.com': 'origin' },
+    '--bacom-blog--adobecom.hlx.live': { 'business.adobe.com': 'origin' },
+    '--bacom-blog--adobecom.hlx.page': { 'business.adobe.com': 'origin' },
+  },
 };
 
 // Load LCP image immediately

--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -113,11 +113,7 @@ const CONFIG = {
   codeRoot: '/blog',
   taxonomyRoot: '/tags',
   links: 'on',
-  stageDomainsMap: {
-    'business.stage.adobe.com': { 'business.adobe.com': 'origin' },
-    '--bacom-blog--adobecom.hlx.live': { 'business.adobe.com': 'origin' },
-    '--bacom-blog--adobecom.hlx.page': { 'business.adobe.com': 'origin' },
-  },
+  stageDomainsMap: { 'business.stage.adobe.com': { 'business.adobe.com': 'origin' } },
 };
 
 // Load LCP image immediately


### PR DESCRIPTION
This PR adds the stageDomainsMap, enabling the conversion of production URLs to their stage equivalents in the stage environment.
More details about this feature can be found in [this discussion](https://github.com/orgs/adobecom/discussions/2880).

Resolves: [MWPW-158449](https://jira.corp.adobe.com/browse/MWPW-158449)

Test URLs:

Before: https://main--bacom-blog--adobecom.hlx.page?martech=off
After: https://mwpw-158449-domains-map--bacom-blog--adobecom.hlx.page?martech=off